### PR TITLE
Move database to folder.

### DIFF
--- a/server/lib/Database.js
+++ b/server/lib/Database.js
@@ -12,7 +12,7 @@ class Database {
   static async open ({ readonly = true, env = process.env } = {}) {
     if (_db) throw new Error('Database already open')
 
-    const dbPath = path.resolve(env.KF_SERVER_PATH_DATA, 'database.sqlite3')
+    const dbPath = path.resolve(env.KF_SERVER_PATH_DATA, 'db/database.sqlite3')
     log.info('Opening database file %s %s', readonly ? '(read-only)' : '(writeable)', dbPath)
 
     const db = await open({


### PR DESCRIPTION
I'm running this in a Docker container and I want to be able to keep the database in a volume. Moving the file to a folder lets me do that without having to put the entire thing in a volume.