### PR TITLE
Making username's case-insensitive

### DIFF
--- a/server/User/User.js
+++ b/server/User/User.js
@@ -95,10 +95,12 @@ class User {
    * @return {Promise}      user object
    */
   static async _get ({ userId, username }, creds) {
+    if (username) username = username.toLowerCase()
+
     const query = sql`
       SELECT *
       FROM users
-      WHERE ${typeof userId === 'number' ? sql`userId = ${userId}` : sql`username = ${username}`}
+      WHERE ${typeof userId === 'number' ? sql`userId = ${userId}` : sql`LOWER(username) = ${username}`}
     `
 
     const user = await db.get(String(query), query.parameters)

--- a/server/User/User.js
+++ b/server/User/User.js
@@ -94,13 +94,11 @@ class User {
    * @param  {Bool}  creds  whether to include username and password in result
    * @return {Promise}      user object
    */
-  static async _get ({ userId, username }, creds) {
-    if (username) username = username.toLowerCase()
-
+  static async _get ({ userId, username }, creds = false) {
     const query = sql`
       SELECT *
       FROM users
-      WHERE ${typeof userId === 'number' ? sql`userId = ${userId}` : sql`LOWER(username) = ${username}`}
+      WHERE ${typeof userId === 'number' ? sql`userId = ${userId}` : sql`LOWER(username) = ${username.toLowerCase()}`}
     `
 
     const user = await db.get(String(query), query.parameters)


### PR DESCRIPTION
Had a guest who couldn't log back in later in the night due to a difference in username case. Maybe an unnecessary restriction?