### PR TITLE
Add CLI KES_PLAYER_DISABLE_WEBGL

### DIFF
--- a/server/lib/cli.js
+++ b/server/lib/cli.js
@@ -20,6 +20,7 @@ const env = {
   KES_SERVER_CONSOLE_LEVEL: parseInt(process.env.KES_SERVER_CONSOLE_LEVEL, 10) || undefined,
   KES_SERVER_LOG_LEVEL: parseInt(process.env.KES_SERVER_LOG_LEVEL, 10) || undefined,
   KES_URL_PATH: process.env.KES_URL_PATH || '/',
+  KES_PLAYER_DISABLE_WEBGL: parseInt(process.env.KES_PLAYER_DISABLE_WEBGL, 10) || undefined,
   // support PUID/PGID convention
   KES_PUID: parseInt(process.env.PUID, 10) || undefined,
   KES_PGID: parseInt(process.env.PGID, 10) || undefined,

--- a/src/lib/getWebGLSupport.js
+++ b/src/lib/getWebGLSupport.js
@@ -1,6 +1,6 @@
 export default function isWebGLSupported () {
   try {
-    return !!window.WebGLRenderingContext && !!document.createElement('canvas').getContext('webgl2')
+    return !!window.WebGLRenderingContext && !!document.createElement('canvas').getContext('webgl2') && !(env.KES_PLAYER_DISABLE_WEBGL)
   } catch (e) {
     return false
   }


### PR DESCRIPTION
The purpose here is to disable visualizations and restore the CDG's original background. This is important for some CDGs that have a complex background or that have multiple singers lyrics in different colors that happen to be the same as the most recent background command.

When KES_PLAYER_DISABLE_WEBGL is not defined or "0" nothing changes. When KES_PLAYER_DISABLE_WEBGL is any number other than "0", WEBGL is disabled.

Please double check this. I don't have a JS IDE or any way to test this. However, I have programmed in more than a dozen languages, including a couple of assembly languages, and this seems like a trivial edit.