### PR TITLE
Feature/co singers

### DIFF
--- a/server/lib/schemas/006-queue-cosingers.sql
+++ b/server/lib/schemas/006-queue-cosingers.sql
@@ -1,0 +1,5 @@
+-- Up
+ALTER TABLE "queue" ADD COLUMN "coSingers" TEXT DEFAULT NULL;
+
+-- Down
+ALTER TABLE "queue" DROP COLUMN "coSingers";

--- a/shared/actionTypes.ts
+++ b/shared/actionTypes.ts
@@ -19,6 +19,7 @@ export const QUEUE_ADD = 'server/QUEUE_ADD'
 export const QUEUE_MOVE = 'server/QUEUE_MOVE'
 export const QUEUE_PUSH = 'queue/PUSH'
 export const QUEUE_REMOVE = 'server/QUEUE_REMOVE'
+export const QUEUE_UPDATE = 'server/QUEUE_UPDATE'
 
 // Player internal
 export const PLAYER_UPDATE = 'player/UPDATE'

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -25,6 +25,7 @@ export interface QueueItem {
   mediaType: 'cdg' | 'mp4'
   isOptimistic?: false
   isVideoKeyingEnabled: boolean
+  coSingers?: string[]
 }
 
 export interface OptimisticQueueItem {

--- a/src/routes/Player/components/PlayerTextOverlay/UpNow/UpNow.css
+++ b/src/routes/Player/components/PlayerTextOverlay/UpNow/UpNow.css
@@ -46,6 +46,12 @@
   max-width: 33vw;
 }
 
+.coSingers {
+  font-size: 4vh;
+  color: var(--color-gray-6);
+  font-style: italic;
+}
+
 .userImage {
   height: 20vh;
 }

--- a/src/routes/Player/components/PlayerTextOverlay/UpNow/UpNow.tsx
+++ b/src/routes/Player/components/PlayerTextOverlay/UpNow/UpNow.tsx
@@ -54,6 +54,9 @@ const UpNow = ({ queueItem }: UpNowProps) => {
           />
           <div className={styles.user}>
             {queueItem.userDisplayName}
+            {queueItem.coSingers && queueItem.coSingers.length > 0 && (
+              <span className={styles.coSingers}> + {queueItem.coSingers.join(', ')}</span>
+            )}
           </div>
         </div>
       </div>

--- a/src/routes/Queue/components/QueueItem/QueueItem.css
+++ b/src/routes/Queue/components/QueueItem/QueueItem.css
@@ -83,6 +83,11 @@
   margin-bottom: 0.25rem;
 }
 
+.coSingers {
+  color: var(--color-gray-6);
+  font-style: italic;
+}
+
 .isOwner {
   color: var(--queued-item-color);
   text-shadow: var(--text-shadow-glow);

--- a/src/routes/Queue/components/QueueItem/QueueItem.tsx
+++ b/src/routes/Queue/components/QueueItem/QueueItem.tsx
@@ -165,6 +165,9 @@ const QueueItem = ({
           </div>
           <div className={clsx(styles.user, isOwner && styles.isOwner)}>
             {userDisplayName}
+            {coSingers && coSingers.length > 0 && (
+              <span className={styles.coSingers}> + {coSingers.join(', ')}</span>
+            )}
           </div>
         </div>
 

--- a/src/routes/Queue/modules/queue.ts
+++ b/src/routes/Queue/modules/queue.ts
@@ -6,6 +6,7 @@ import {
   QUEUE_MOVE,
   QUEUE_PUSH,
   QUEUE_REMOVE,
+  QUEUE_UPDATE,
   LOGOUT,
 } from 'shared/actionTypes'
 import type { QueueItem, OptimisticQueueItem } from 'shared/types'
@@ -22,6 +23,8 @@ export const queueSong = createAction(QUEUE_ADD, (songId: number) => ({
   payload: { songId },
   meta: { isOptimistic: true },
 }))
+
+export const updateCoSingers = createAction<{ queueId: number, coSingers: string[] }>(QUEUE_UPDATE)
 
 export const removeUpcomingItems = (userId: number): AppThunk => (dispatch: AppDispatch, getState: () => RootState) => {
   const upcomingQueueIds = getUpcoming(getState(), userId)


### PR DESCRIPTION
## Summary

Add support for co-singers in the queue, allowing users to indicate who will be singing with them.

### Features
- New `coSingers` field in queue items (stored as JSON array in SQLite)
- Users can edit co-singers for their upcoming songs via the swipe menu (person icon)
- Co-singers are displayed alongside the main singer's name
- Database migration `006-queue-cosingers.sql` adds the column

### Bug Fix
- Fix linked-list corruption when queue data becomes inconsistent (defensive null check in traversal loop)

> _Note_: Includes a minor defensive fix in Queue.get() to prevent potential crashes if linked-list data becomes inconsistent. Happy to split into a separate PR if preferred.

### Files Changed
- `server/lib/schemas/006-queue-cosingers.sql` - DB migration
- `server/Queue/Queue.ts` - add/get/update methods
- `server/Queue/socket.ts` - QUEUE_UPDATE handler
- `shared/types.ts` - QueueItem interface
- `shared/actionTypes.ts` - QUEUE_UPDATE action
- `src/routes/Queue/components/QueueItem/QueueItem.tsx` - Edit button UI
- `src/routes/Queue/modules/queue.ts` - Redux action

## Test Plan
- ✅ Add a song to the queue
- ✅ Swipe left on your upcoming song
- ✅ Tap the person icon to edit co-singers
- ✅ Enter names separated by commas
- ✅ Verify co-singers display in queue item
- ✅ Verify co-singers persist after page refresh